### PR TITLE
Fix for agent setup failing on localhost

### DIFF
--- a/ambari-server/src/main/python/setupAgent.py
+++ b/ambari-server/src/main/python/setupAgent.py
@@ -240,8 +240,8 @@ def configureAgent(server_hostname, cwd, ret=None):
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def configureAgent(server_hostname, user_run_as):
   """ Configure the agent so that it has all the configs knobs properly installed """
-  osCommand = ["sed", "-i.bak", "s/hostname=localhost/hostname=" + server_hostname +
-                                "/g", "/etc/ambari-agent/conf/ambari-agent.ini"]
+  osCommand = ["sed", "-i.bak", "s/^hostname=localhost$/hostname=" + server_hostname +
+                                "/", "/etc/ambari-agent/conf/ambari-agent.ini"]
   ret = execOsCommand(osCommand)
   if ret['exitstatus'] != 0:
     return ret


### PR DESCRIPTION
When installing the agent on the same machine (for testing or learning purposes) using "localhost.whatever" as FQDN, the agent configuration is messed up by `configureAgent`. As the obvious purpose there is to replace the default "hostname=localhost" with whatever the user is provided, it makes sense to make the match more exact.